### PR TITLE
Add build status badge to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # DB Taxes
 
+[![Go](https://github.com/theilgaard/db_taxes/actions/workflows/unittest.yml/badge.svg?branch=master)](https://github.com/theilgaard/db_taxes/actions/workflows/unittest.yml)
+
 This application solves managing taxes applied in different municipalities. The application uses a sqlite database, and implements a RESTful API.
 
 The following assumptions were made:


### PR DESCRIPTION
Fixes #5

Add a build status badge to the `readme.md` file.

* Add the build status badge markdown code at the top of the file.
* Use the provided URL for the badge image and link.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/theilgaard/db_taxes/issues/5?shareId=97e79bea-2ce5-4db1-b3a9-d279153636f9).