### PR TITLE
Separate resource and properties in the REST endpoints

### DIFF
--- a/bruno/GetRecordsByMunicipalityAndDate.bru
+++ b/bruno/GetRecordsByMunicipalityAndDate.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://{{host}}:{{port}}/records/{{test_municipality}}/{{test_date}}
+  url: http://{{host}}:{{port}}/records/{{test_municipality}}?date={{test_date}}
   body: none
   auth: none
 }

--- a/bruno/tests/test_1.bru
+++ b/bruno/tests/test_1.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://{{host}}:{{port}}/records/{{test_municipality}}/2024-01-01
+  url: http://{{host}}:{{port}}/records/{{test_municipality}}?date=2024-01-01
   body: none
   auth: none
 }

--- a/bruno/tests/test_2.bru
+++ b/bruno/tests/test_2.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://{{host}}:{{port}}/records/{{test_municipality}}/2024-03-16
+  url: http://{{host}}:{{port}}/records/{{test_municipality}}?date=2024-03-16
   body: none
   auth: none
 }

--- a/bruno/tests/test_3.bru
+++ b/bruno/tests/test_3.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://{{host}}:{{port}}/records/{{test_municipality}}/2024-05-02
+  url: http://{{host}}:{{port}}/records/{{test_municipality}}?date=2024-05-02
   body: none
   auth: none
 }

--- a/bruno/tests/test_4.bru
+++ b/bruno/tests/test_4.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://{{host}}:{{port}}/records/{{test_municipality}}/2024-07-10
+  url: http://{{host}}:{{port}}/records/{{test_municipality}}?date=2024-07-10
   body: none
   auth: none
 }

--- a/bruno/tests/test_parsing_error.bru
+++ b/bruno/tests/test_parsing_error.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://{{host}}:{{port}}/records/{{test_municipality}}/unparsable_date
+  url: http://{{host}}:{{port}}/records/{{test_municipality}}?date=unparsable_date
   body: none
   auth: none
 }

--- a/db_taxes.go
+++ b/db_taxes.go
@@ -91,7 +91,7 @@ func getTaxRecordsByMunicipalityAndDate(db *sql.DB) gin.HandlerFunc {
 		// Both municipality and date specified, return single record for that municipality and date
 		// Precedence on period_type is made by Daily, Weekly, Monthly, Yearly as 1, 2, 3, 4 respectively.
 		municipality := c.Param("municipality")
-		date := c.Param("date")
+		date := c.Query("date")
 		date_time, err := time.Parse(time.DateOnly, date)
 		if err != nil {
 			log.Println(err)
@@ -175,7 +175,8 @@ func configureServer(db *sql.DB) *gin.Engine {
 	router := gin.Default()
 	router.GET("/records", getTaxRecords(db))
 	router.GET("/records/:municipality", getTaxRecordsByMunicipality(db))
-	router.GET("/records/:municipality/:date", getTaxRecordsByMunicipalityAndDate(db))
+	router.GET("/records/:municipality", getTaxRecordsByMunicipalityAndDate(db))
+
 	router.POST("/records", postTaxRecord(db))
 
 	return router

--- a/db_taxes_test.go
+++ b/db_taxes_test.go
@@ -22,7 +22,7 @@ func TestAPIEndpoints(t *testing.T) {
 	ts := setupTestServer()
 	defer ts.Close()
 
-	test_url := "/records/Copenhagen/2024-01-01"
+	test_url := "/records/Copenhagen?date=2024-01-01"
 	expected_tax_rate := 0.1
 	t.Run("Success GET "+test_url, func(t *testing.T) {
 		resp, err := http.Get(ts.URL + test_url)
@@ -39,7 +39,7 @@ func TestAPIEndpoints(t *testing.T) {
 		assert.Equal(t, expected_tax_rate, tax_records[0].TaxRate)
 	})
 
-	test_url = "/records/Copenhagen/2024-03-16"
+	test_url = "/records/Copenhagen?date=2024-03-16"
 	expected_tax_rate = 0.2
 	t.Run("Success GET "+test_url, func(t *testing.T) {
 		resp, err := http.Get(ts.URL + test_url)
@@ -56,7 +56,7 @@ func TestAPIEndpoints(t *testing.T) {
 		assert.Equal(t, expected_tax_rate, tax_records[0].TaxRate)
 	})
 
-	test_url = "/records/Copenhagen/2024-05-02"
+	test_url = "/records/Copenhagen?date=2024-05-02"
 	expected_tax_rate = 0.4
 	t.Run("Success GET "+test_url, func(t *testing.T) {
 		resp, err := http.Get(ts.URL + test_url)
@@ -73,7 +73,7 @@ func TestAPIEndpoints(t *testing.T) {
 		assert.Equal(t, expected_tax_rate, tax_records[0].TaxRate)
 	})
 
-	test_url = "/records/Copenhagen/2024-07-10"
+	test_url = "/records/Copenhagen?date=2024-07-10"
 	expected_tax_rate = 0.2
 	t.Run("Success GET "+test_url, func(t *testing.T) {
 		resp, err := http.Get(ts.URL + test_url)
@@ -90,7 +90,7 @@ func TestAPIEndpoints(t *testing.T) {
 		assert.Equal(t, expected_tax_rate, tax_records[0].TaxRate)
 	})
 
-	test_url = "/records/Copenhagen/invalid_date_format"
+	test_url = "/records/Copenhagen?date=invalid_date_format"
 	expected_tax_rate = 0.2
 	t.Run("Invalid Date Format GET "+test_url, func(t *testing.T) {
 		resp, err := http.Get(ts.URL + test_url)


### PR DESCRIPTION
Fixes #8

Update REST endpoints to use date as a query parameter instead of a URL path.

* **db_taxes.go**
  - Modify `getTaxRecordsByMunicipalityAndDate` to retrieve the date from the query parameter.
  - Change the endpoint URL in `configureServer` to use the query parameter for the date.

* **db_taxes_test.go**
  - Update test cases to use the date as a query parameter in the endpoint URL.

* **bruno/GetRecordsByMunicipalityAndDate.bru**
  - Change the endpoint URL to use the date as a query parameter.

* **bruno/tests/test_1.bru**, **bruno/tests/test_2.bru**, **bruno/tests/test_3.bru**, **bruno/tests/test_4.bru**, **bruno/tests/test_parsing_error.bru**
  - Update the endpoint URLs to use the date as a query parameter.

* **bruno/environments/localhost.bru**
  - Update the `test_date` variable to be used as a query parameter in the endpoint URL.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/theilgaard/db_taxes/issues/8?shareId=2a894dac-a574-448e-8b1d-aca5542f833a).