### PR TITLE
Refactor folder structure to be more idiomatic

### DIFF
--- a/cmd/db_taxes/db_taxes.go
+++ b/cmd/db_taxes/db_taxes.go
@@ -138,20 +138,3 @@ func configureServer(db *sql.DB) *gin.Engine {
 
 	return router
 }
-
-func main() {
-	// Initialize the database
-	database, err := db.InitializeDatabase()
-	if err != nil {
-		log.Fatalf("Failed to initialize database: %v", err)
-	}
-
-	// Populate the database with initial records
-	if err := db.PopulateDatabase(database); err != nil {
-		log.Fatalf("Failed to populate database: %v", err)
-	}
-
-	// Run the server
-	router := configureServer(database)
-	router.Run(":8080")
-}

--- a/cmd/db_taxes/main.go
+++ b/cmd/db_taxes/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"log"
+	"theilgaard/db_taxes/internal/db"
+)
+
+func main() {
+	// Initialize the database
+	database, err := db.InitializeDatabase()
+	if err != nil {
+		log.Fatalf("Failed to initialize database: %v", err)
+	}
+
+	// Populate the database with initial records
+	if err := db.PopulateDatabase(database); err != nil {
+		log.Fatalf("Failed to populate database: %v", err)
+	}
+
+	// Run the server
+	router := configureServer(database)
+	router.Run(":8080")
+}

--- a/internal/db/init.go
+++ b/internal/db/init.go
@@ -1,0 +1,84 @@
+package db
+
+import (
+	"database/sql"
+	"time"
+	"log"
+	_ "github.com/mattn/go-sqlite3" // sqlite3 driver
+)
+
+const db_driver string = "sqlite3"
+const db_location string = "tax_records.db"
+
+type TaxRecord struct {
+	Municipality string    `json:"municipality"`
+	PeriodType   int       `json:"period_type"`
+	DateStart    time.Time `json:"date_start"`
+	DateEnd      time.Time `json:"date_end"`
+	TaxRate      float64   `json:"tax_rate"`
+}
+
+func getInitialTaxRecords() []TaxRecord {
+	yearly_start_time, _ := time.Parse(time.DateOnly, "2024-01-01")
+	yearly_end_time, _ := time.Parse(time.DateOnly, "2024-12-31")
+	monthly_start_time, _ := time.Parse(time.DateOnly, "2024-05-01")
+	monthly_end_time, _ := time.Parse(time.DateOnly, "2024-05-31")
+	daily_1_start_time, _ := time.Parse(time.DateOnly, "2024-01-01")
+	daily_1_end_time, _ := time.Parse(time.DateOnly, "2024-01-01")
+	daily_2_start_time, _ := time.Parse(time.DateOnly, "2024-12-25")
+	daily_2_end_time, _ := time.Parse(time.DateOnly, "2024-12-25")
+
+	var tax_records = []TaxRecord{
+		{Municipality: "Copenhagen", PeriodType: 4, DateStart: yearly_start_time, DateEnd: yearly_end_time, TaxRate: 0.2},
+		{Municipality: "Copenhagen", PeriodType: 3, DateStart: monthly_start_time, DateEnd: monthly_end_time, TaxRate: 0.4},
+		{Municipality: "Copenhagen", PeriodType: 1, DateStart: daily_1_start_time, DateEnd: daily_1_end_time, TaxRate: 0.1},
+		{Municipality: "Copenhagen", PeriodType: 1, DateStart: daily_2_start_time, DateEnd: daily_2_end_time, TaxRate: 0.1},
+		{Municipality: "Aarhus", PeriodType: 4, DateStart: yearly_start_time, DateEnd: yearly_end_time, TaxRate: 0.5},
+	}
+	return tax_records
+}
+
+func initializeDatabase() (*sql.DB, error) {
+	// Initialize the database with some initial records
+	db, err := sql.Open(db_driver, db_location)
+	if (err != nil) {
+		return nil, err
+	}
+
+	const drop string = "DROP TABLE IF EXISTS tax_records;"
+	if _, err := db.Exec(drop); err != nil {
+		return nil, err
+	}
+
+	const create string = `
+		CREATE TABLE tax_records (
+			id INTEGER NOT NULL PRIMARY KEY,
+			municipality TEXT NOT NULL,
+			period_type INT NOT NULL,
+			date_start DATETIME NOT NULL,
+			date_end DATETIME NOT NULL,
+			tax_rate REAL NOT NULL
+	);`
+	if _, err := db.Exec(create); err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+func insertTaxRecord(db *sql.DB, record TaxRecord) error {
+	const insert string = `
+		INSERT INTO tax_records (municipality, period_type, date_start, date_end, tax_rate)
+		VALUES (?, ?, ?, ?, ?);`
+	_, err := db.Exec(insert, record.Municipality, record.PeriodType, record.DateStart, record.DateEnd, record.TaxRate)
+	return err
+}
+
+func populateDatabase(db *sql.DB) error {
+	// Insert the initial records into the database
+	for _, record := range getInitialTaxRecords() {
+		if err := insertTaxRecord(db, record); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/db/init.go
+++ b/internal/db/init.go
@@ -37,7 +37,7 @@ func getInitialTaxRecords() []TaxRecord {
 	return tax_records
 }
 
-func initializeDatabase() (*sql.DB, error) {
+func InitializeDatabase() (*sql.DB, error) {
 	// Initialize the database with some initial records
 	db, err := sql.Open(db_driver, db_location)
 	if (err != nil) {
@@ -72,7 +72,7 @@ func insertTaxRecord(db *sql.DB, record TaxRecord) error {
 	return err
 }
 
-func populateDatabase(db *sql.DB) error {
+func PopulateDatabase(db *sql.DB) error {
 	// Insert the initial records into the database
 	for _, record := range getInitialTaxRecords() {
 		if err := insertTaxRecord(db, record); err != nil {

--- a/internal/db/init.go
+++ b/internal/db/init.go
@@ -3,7 +3,6 @@ package db
 import (
 	"database/sql"
 	"time"
-	"log"
 	_ "github.com/mattn/go-sqlite3" // sqlite3 driver
 )
 

--- a/tests/db_taxes_test.go
+++ b/tests/db_taxes_test.go
@@ -10,12 +10,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"theilgaard/db_taxes/internal/db"
 )
 
 func setupTestServer() *httptest.Server {
-	db, _ := initializeDatabase()
-	populateDatabase(db)
-	return httptest.NewServer(configureServer(db))
+	database, _ := db.InitializeDatabase()
+	db.PopulateDatabase(database)
+	return httptest.NewServer(configureServer(database))
 }
 
 func TestAPIEndpoints(t *testing.T) {
@@ -33,7 +34,7 @@ func TestAPIEndpoints(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		response_bytes, _ := io.ReadAll(resp.Body)
-		tax_records := []TaxRecord{}
+		tax_records := []db.TaxRecord{}
 		json.Unmarshal(response_bytes, &tax_records)
 
 		assert.Equal(t, expected_tax_rate, tax_records[0].TaxRate)
@@ -50,7 +51,7 @@ func TestAPIEndpoints(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		response_bytes, _ := io.ReadAll(resp.Body)
-		tax_records := []TaxRecord{}
+		tax_records := []db.TaxRecord{}
 		json.Unmarshal(response_bytes, &tax_records)
 
 		assert.Equal(t, expected_tax_rate, tax_records[0].TaxRate)
@@ -67,7 +68,7 @@ func TestAPIEndpoints(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		response_bytes, _ := io.ReadAll(resp.Body)
-		tax_records := []TaxRecord{}
+		tax_records := []db.TaxRecord{}
 		json.Unmarshal(response_bytes, &tax_records)
 
 		assert.Equal(t, expected_tax_rate, tax_records[0].TaxRate)
@@ -84,7 +85,7 @@ func TestAPIEndpoints(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		response_bytes, _ := io.ReadAll(resp.Body)
-		tax_records := []TaxRecord{}
+		tax_records := []db.TaxRecord{}
 		json.Unmarshal(response_bytes, &tax_records)
 
 		assert.Equal(t, expected_tax_rate, tax_records[0].TaxRate)
@@ -101,7 +102,7 @@ func TestAPIEndpoints(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 		response_bytes, _ := io.ReadAll(resp.Body)
-		tax_records := []TaxRecord{}
+		tax_records := []db.TaxRecord{}
 		json.Unmarshal(response_bytes, &tax_records)
 
 		assert.Contains(t, string(response_bytes), "Invalid date format")
@@ -110,7 +111,7 @@ func TestAPIEndpoints(t *testing.T) {
 	test_url = "/records/"
 	kolding_start_date, _ := time.Parse(time.DateOnly, "2024-01-01")
 	kolding_end_date, _ := time.Parse(time.DateOnly, "2024-12-31")
-	kolding_tax_record := TaxRecord{Municipality: "Kolding", PeriodType: 4, DateStart: kolding_start_date, DateEnd: kolding_end_date, TaxRate: 0.2}
+	kolding_tax_record := db.TaxRecord{Municipality: "Kolding", PeriodType: 4, DateStart: kolding_start_date, DateEnd: kolding_end_date, TaxRate: 0.2}
 	kolding_tax_record_json, _ := json.Marshal(kolding_tax_record)
 	t.Run("Success POST "+test_url, func(t *testing.T) {
 		resp, err := http.Post(ts.URL+test_url, "application/json", bytes.NewBuffer(kolding_tax_record_json))
@@ -128,7 +129,7 @@ func TestInsertAndReadRecord(t *testing.T) {
 	defer ts.Close()
 
 	test_url := "/records/"
-	new_record := TaxRecord{
+	new_record := db.TaxRecord{
 		Municipality: "TestCity",
 		PeriodType:   3,
 		DateStart:    time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC),
@@ -155,7 +156,7 @@ func TestInsertAndReadRecord(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		response_bytes, _ := io.ReadAll(resp.Body)
-		tax_records := []TaxRecord{}
+		tax_records := []db.TaxRecord{}
 		json.Unmarshal(response_bytes, &tax_records)
 
 		assert.Equal(t, 1, len(tax_records))

--- a/tests/db_taxes_test.go
+++ b/tests/db_taxes_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"theilgaard/db_taxes/internal/db"
+	"theilgaard/db_taxes/cmd/db_taxes" // Import the configureServer function
 )
 
 func setupTestServer() *httptest.Server {


### PR DESCRIPTION
Fixes #12

Refactor the folder structure to better organize the test and main Go application files.

* **Main Application**: 
  - Create `cmd/db_taxes/main.go` with the `main` function to initialize and populate the database and run the server.
  - Move `initializeDatabase` and `populateDatabase` functions to `internal/db/init.go`.
  - Update `cmd/db_taxes/db_taxes.go` to remove the `initializeDatabase` and `populateDatabase` functions and call them from `internal/db/init.go`.

* **Tests**:
  - Move `db_taxes_test.go` to `tests/db_taxes_test.go`.
  - Update imports in `tests/db_taxes_test.go` to use the `db` package from `internal/db/init.go`.
  - Update the `setupTestServer` function in `tests/db_taxes_test.go` to call the `initializeDatabase` and `populateDatabase` functions from `internal/db/init.go`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/theilgaard/db_taxes/issues/12?shareId=840e9252-e14d-49ba-b3b9-154976bdb7e1).