### PR TITLE
Use query parameters on all endpoint attributes

### DIFF
--- a/bruno/GetRecordsByMunicipality.bru
+++ b/bruno/GetRecordsByMunicipality.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://{{host}}:{{port}}/records/{{test_municipality}}
+  url: http://{{host}}:{{port}}/records?municipality={{test_municipality}}
   body: none
   auth: none
 }

--- a/bruno/GetRecordsByMunicipalityAndDate.bru
+++ b/bruno/GetRecordsByMunicipalityAndDate.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://{{host}}:{{port}}/records/{{test_municipality}}?date={{test_date}}
+  url: http://{{host}}:{{port}}/records?municipality={{test_municipality}}&date={{test_date}}
   body: none
   auth: none
 }

--- a/bruno/tests/test_1.bru
+++ b/bruno/tests/test_1.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://{{host}}:{{port}}/records/{{test_municipality}}?date=2024-01-01
+  url: http://{{host}}:{{port}}/records?municipality={{test_municipality}}&date=2024-01-01
   body: none
   auth: none
 }

--- a/bruno/tests/test_2.bru
+++ b/bruno/tests/test_2.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://{{host}}:{{port}}/records/{{test_municipality}}?date=2024-03-16
+  url: http://{{host}}:{{port}}/records?municipality={{test_municipality}}&date=2024-03-16
   body: none
   auth: none
 }

--- a/bruno/tests/test_3.bru
+++ b/bruno/tests/test_3.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://{{host}}:{{port}}/records/{{test_municipality}}?date=2024-05-02
+  url: http://{{host}}:{{port}}/records?municipality={{test_municipality}}&date=2024-05-02
   body: none
   auth: none
 }

--- a/bruno/tests/test_4.bru
+++ b/bruno/tests/test_4.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://{{host}}:{{port}}/records/{{test_municipality}}?date=2024-07-10
+  url: http://{{host}}:{{port}}/records?municipality={{test_municipality}}&date=2024-07-10
   body: none
   auth: none
 }

--- a/bruno/tests/test_parsing_error.bru
+++ b/bruno/tests/test_parsing_error.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://{{host}}:{{port}}/records/{{test_municipality}}?date=unparsable_date
+  url: http://{{host}}:{{port}}/records?municipality={{test_municipality}}&date=unparsable_date
   body: none
   auth: none
 }

--- a/cmd/db_taxes/db_taxes_test.go
+++ b/cmd/db_taxes/db_taxes_test.go
@@ -22,7 +22,7 @@ func TestAPIEndpoints(t *testing.T) {
 	ts := setupTestServer()
 	defer ts.Close()
 
-	test_url := "/records/Copenhagen?date=2024-01-01"
+	test_url := "/records?municipality=Copenhagen&date=2024-01-01"
 	expected_tax_rate := 0.1
 	t.Run("Success GET "+test_url, func(t *testing.T) {
 		resp, err := http.Get(ts.URL + test_url)
@@ -39,7 +39,7 @@ func TestAPIEndpoints(t *testing.T) {
 		assert.Equal(t, expected_tax_rate, tax_records[0].TaxRate)
 	})
 
-	test_url = "/records/Copenhagen?date=2024-03-16"
+	test_url = "/records?municipality=Copenhagen&date=2024-03-16"
 	expected_tax_rate = 0.2
 	t.Run("Success GET "+test_url, func(t *testing.T) {
 		resp, err := http.Get(ts.URL + test_url)
@@ -56,7 +56,7 @@ func TestAPIEndpoints(t *testing.T) {
 		assert.Equal(t, expected_tax_rate, tax_records[0].TaxRate)
 	})
 
-	test_url = "/records/Copenhagen?date=2024-05-02"
+	test_url = "/records?municipality=Copenhagen&date=2024-05-02"
 	expected_tax_rate = 0.4
 	t.Run("Success GET "+test_url, func(t *testing.T) {
 		resp, err := http.Get(ts.URL + test_url)
@@ -73,7 +73,7 @@ func TestAPIEndpoints(t *testing.T) {
 		assert.Equal(t, expected_tax_rate, tax_records[0].TaxRate)
 	})
 
-	test_url = "/records/Copenhagen?date=2024-07-10"
+	test_url = "/records?municipality=Copenhagen&date=2024-07-10"
 	expected_tax_rate = 0.2
 	t.Run("Success GET "+test_url, func(t *testing.T) {
 		resp, err := http.Get(ts.URL + test_url)
@@ -90,7 +90,7 @@ func TestAPIEndpoints(t *testing.T) {
 		assert.Equal(t, expected_tax_rate, tax_records[0].TaxRate)
 	})
 
-	test_url = "/records/Copenhagen?date=invalid_date_format"
+	test_url = "/records?municipality=Copenhagen&date=invalid_date_format"
 	expected_tax_rate = 0.2
 	t.Run("Invalid Date Format GET "+test_url, func(t *testing.T) {
 		resp, err := http.Get(ts.URL + test_url)
@@ -147,7 +147,7 @@ func TestInsertAndReadRecord(t *testing.T) {
 	})
 
 	t.Run("Read Inserted Record", func(t *testing.T) {
-		resp, err := http.Get(ts.URL + "/records/TestCity?date=2024-06-15")
+		resp, err := http.Get(ts.URL + "/records?municipality=TestCity&date=2024-06-15")
 		if err != nil {
 			t.Fatalf("Failed to send GET request: %v", err)
 		}


### PR DESCRIPTION
Fixes #17

Update all endpoint attributes to use query parameters.

* Modify `bruno/GetRecordsByMunicipality.bru` to use municipality as a query parameter.
* Modify `bruno/GetRecordsByMunicipalityAndDate.bru` to use both municipality and date as query parameters.
* Update test files (`bruno/tests/test_1.bru`, `bruno/tests/test_2.bru`, `bruno/tests/test_3.bru`, `bruno/tests/test_4.bru`, `bruno/tests/test_parsing_error.bru`) to use both municipality and date as query parameters.
* Modify `cmd/db_taxes/db_taxes.go` to update the `getTaxRecordsByMunicipalityAndDate` function to use both municipality and date as query parameters, and remove the `getTaxRecords` function and its route.
* Update `cmd/db_taxes/db_taxes_test.go` to use both municipality and date as query parameters in test URLs and replace `c.Param("municipality")` with `c.Query("municipality")`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/theilgaard/db_taxes/issues/17?shareId=c6b510db-d700-4d0a-aeda-76a4cb6d3115).